### PR TITLE
Pause on Autosave - Quality of life improvement

### DIFF
--- a/Languages/Chinese/Keyed/Multiplayer.xml
+++ b/Languages/Chinese/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>玩RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>不在多人游戏中</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN本地</MpLan>
   <MpDirect>Direct直连</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>Playing RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>Not in multiplayer</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Direct</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/French/Keyed/Multiplayer.xml
+++ b/Languages/French/Keyed/Multiplayer.xml
@@ -92,6 +92,7 @@
   <MpPlayingRimWorld>Entrain de jouer à RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>Pas dans le Multijoueur</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Directe</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/German/Keyed/Multiplayer.xml
+++ b/Languages/German/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>Spielt RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>Nicht verfügbar im Mehrspieler-Modus</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Direkt</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Hungarian/Keyed/Multiplayer.xml
+++ b/Languages/Hungarian/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>RimWorldel játszik</MpPlayingRimWorld>
   <MpNotInMultiplayer>Nincs többjátékos módban</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Közvetlen</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Korean/Keyed/Multiplayer.xml
+++ b/Languages/Korean/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>림월드 플레이 중</MpPlayingRimWorld>
   <MpNotInMultiplayer>멀티중 아님</MpNotInMultiplayer>
 
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>직접 연결</MpDirect>
   <MpSteam>스팀</MpSteam>

--- a/Languages/Polish/Keyed/Multiplayer.xml
+++ b/Languages/Polish/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>Grają w RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>Nie połączony do gry wieloosobowej</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Bezpośrednio</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/PortugueseBrazilian/Keyed/Multiplayer.xml
+++ b/Languages/PortugueseBrazilian/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>Jogando RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>Não está em modo multijogador</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Direto</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Russian/Keyed/Multiplayer.xml
+++ b/Languages/Russian/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>Играет в RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>Не в мультиплеере</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Прямое</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Slovenian/Keyed/Multiplayer.xml
+++ b/Languages/Slovenian/Keyed/Multiplayer.xml
@@ -111,6 +111,7 @@
   <MpPlayingRimWorld>Igranje RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>Ne igraš na več igralcev</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Direktno</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Spanish/Keyed/Multiplayer.xml
+++ b/Languages/Spanish/Keyed/Multiplayer.xml
@@ -110,6 +110,7 @@
   <MpPlayingRimWorld>Jugando RimWorld</MpPlayingRimWorld>
   <MpNotInMultiplayer>No está en multijugador</MpNotInMultiplayer>
   
+  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpLan>LAN</MpLan>
   <MpDirect>Directo</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -95,6 +95,13 @@ namespace Multiplayer.Client
 
             var checkboxWidth = labelWidth + 30f;
 
+            var pauseOnAutosaveLabel = $"{"MpPauseOnAutosave".Translate()}:  ";
+            var pauseOnAutosaveLabelWidth = Text.CalcSize(pauseOnAutosaveLabel).x;
+            var pauseOnAutosaveCheckboxWidth = pauseOnAutosaveLabelWidth + 30f;
+            CheckboxLabeled(entry.Width(pauseOnAutosaveCheckboxWidth), pauseOnAutosaveLabel, ref settings.pauseOnAutosave, placeTextNearCheckbox: true);
+
+            entry = entry.Down(30);
+
             var directLabel = $"{"MpDirect".Translate()}:  ";
             var directLabelWidth = Text.CalcSize(directLabel).x;
             CheckboxLabeled(entry.Width(checkboxWidth), directLabel, ref direct, placeTextNearCheckbox: true);

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -203,6 +203,9 @@ namespace Multiplayer.Common
             if (tmpMapCmds != null)
                 return false;
 
+            if (settings.pauseOnAutosave)
+                SendCommand(CommandType.WorldTimeSpeed, ScheduledCommand.NoFaction, ScheduledCommand.Global, new byte[] { (byte)Verse.TimeSpeed.Paused });
+
             SendCommand(CommandType.Autosave, ScheduledCommand.NoFaction, ScheduledCommand.Global, new byte[0]);
             tmpMapCmds = new Dictionary<int, List<byte[]>>();
 
@@ -414,6 +417,7 @@ namespace Multiplayer.Common
         public string lanAddress;
         public int maxPlayers = 8;
         public int autosaveInterval = 8;
+        public bool pauseOnAutosave = false;
         public bool steam;
         public bool arbiter;
     }


### PR DESCRIPTION
When playing with friends, the autosave feature would often be a cause of frustration, because some players' computers would complete the save process before others, and the game would resume without them. Those players would then need to catch up. Under normal circumstances this would be okay, but when in a moment of stress, like during combat, this could cause some real issues for the players who were behind. This change allows the host to toggle a
new option that simply pauses the world when an autosave happens. Once complete, any user can resume the game as normal.
The new option defaults to off so the existing user experience is preserved.
Language entries for every language were created, but each contains the English translation (these will need to be localized) 