### PR TITLE
Improved autosave feature

### DIFF
--- a/Languages/Chinese/Keyed/Multiplayer.xml
+++ b/Languages/Chinese/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>游戏名</MpGameName>
   <MpMaxPlayers>最多玩家</MpMaxPlayers>
   <MpAutosaveEvery>自动保存每</MpAutosaveEvery>
-  <MpAutosaveMinutes>分钟</MpAutosaveMinutes>
+  <MpAutosaveDays>天</MpAutosaveDays>
   <MpLanDesc1>播放游戏到本地网络</MpLanDesc1>
   <MpLanDesc2>本地地址: {0}</MpLanDesc2>
   <MpArbiterDesc>Arbiter在游戏后端帮用户同步</MpArbiterDesc>

--- a/Languages/Chinese/Keyed/Multiplayer.xml
+++ b/Languages/Chinese/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN本地</MpLan>
   <MpDirect>Direct直连</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>Game name</MpGameName>
   <MpMaxPlayers>Max players</MpMaxPlayers>
   <MpAutosaveEvery>Autosave every</MpAutosaveEvery>
-  <MpAutosaveMinutes>minutes</MpAutosaveMinutes>
+  <MpAutosaveDays>days</MpAutosaveDays>
   <MpLanDesc1>Broadcast the game to your local network.</MpLanDesc1>
   <MpLanDesc2>Resolved LAN address: {0}</MpLanDesc2>
   <MpArbiterDesc>A game instance which runs in the background and helps with desync solving.</MpArbiterDesc>

--- a/Languages/English/Keyed/Multiplayer.xml
+++ b/Languages/English/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Direct</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/French/Keyed/Multiplayer.xml
+++ b/Languages/French/Keyed/Multiplayer.xml
@@ -68,7 +68,7 @@
   <MpGameName>Nom de la partie</MpGameName>
   <MpMaxPlayers>Joueurs maximum</MpMaxPlayers>
   <MpAutosaveEvery>Fréquence sauvegarde auto</MpAutosaveEvery>
-  <MpAutosaveMinutes>minutes</MpAutosaveMinutes>
+  <MpAutosaveDays>days</MpAutosaveDays>
   <MpLanDesc1>Diffuser la partie sur votre réseau local.</MpLanDesc1>
   <MpLanDesc2>Adresse LAN déterminée: {0}</MpLanDesc2>
   <MpArbiterDesc>Une instance du jeu tournant dans le fond et qui aide avec les problèmes de désynchronisation.</MpArbiterDesc>

--- a/Languages/French/Keyed/Multiplayer.xml
+++ b/Languages/French/Keyed/Multiplayer.xml
@@ -68,7 +68,7 @@
   <MpGameName>Nom de la partie</MpGameName>
   <MpMaxPlayers>Joueurs maximum</MpMaxPlayers>
   <MpAutosaveEvery>Fréquence sauvegarde auto</MpAutosaveEvery>
-  <MpAutosaveDays>days</MpAutosaveDays>
+  <MpAutosaveDays>journées</MpAutosaveDays>
   <MpLanDesc1>Diffuser la partie sur votre réseau local.</MpLanDesc1>
   <MpLanDesc2>Adresse LAN déterminée: {0}</MpLanDesc2>
   <MpArbiterDesc>Une instance du jeu tournant dans le fond et qui aide avec les problèmes de désynchronisation.</MpArbiterDesc>

--- a/Languages/French/Keyed/Multiplayer.xml
+++ b/Languages/French/Keyed/Multiplayer.xml
@@ -94,6 +94,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Directe</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/German/Keyed/Multiplayer.xml
+++ b/Languages/German/Keyed/Multiplayer.xml
@@ -112,7 +112,8 @@
   
   <MpPauseOnAutosave>Pausieren bei Autosave</MpPauseOnAutosave>  
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
-
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Direkt</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/German/Keyed/Multiplayer.xml
+++ b/Languages/German/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>Spielname</MpGameName>
   <MpMaxPlayers>Max. Spieler</MpMaxPlayers>
   <MpAutosaveEvery>Automatisches Speichern jede</MpAutosaveEvery>
-  <MpAutosaveMinutes>Minuten</MpAutosaveMinutes>
+  <MpAutosaveDays>Tage</MpAutosaveDays>
   <MpLanDesc1>Übertragen Sie das Spiel in Ihr lokales Netzwerk.</MpLanDesc1>
   <MpLanDesc2>Aufgelöste LAN adresse: {0}</MpLanDesc2>
   <MpArbiterDesc>Eine Spielinstance, welche im Hintergrund arbeitet und dabei hilft desync Probleme zu beheben.</MpArbiterDesc>

--- a/Languages/Hungarian/Keyed/Multiplayer.xml
+++ b/Languages/Hungarian/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Közvetlen</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Hungarian/Keyed/Multiplayer.xml
+++ b/Languages/Hungarian/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>Játék neve</MpGameName>
   <MpMaxPlayers>Max játékosok</MpMaxPlayers>
   <MpAutosaveEvery>Automatikus mentés</MpAutosaveEvery>
-  <MpAutosaveMinutes>percenként</MpAutosaveMinutes>
+  <MpAutosaveDays>napok</MpAutosaveDays>
   <MpLanDesc1>A játék hírdetése helyi hálózaton</MpLanDesc1>
   <MpLanDesc2>LAN cím: {0}</MpLanDesc2>
   <MpArbiterDesc>Egy játékfolyamat, ami a háttérben futva segít a szinkronizáció megtartásában.</MpArbiterDesc>

--- a/Languages/Korean/Keyed/Multiplayer.xml
+++ b/Languages/Korean/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
 
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>직접 연결</MpDirect>
   <MpSteam>스팀</MpSteam>

--- a/Languages/Korean/Keyed/Multiplayer.xml
+++ b/Languages/Korean/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>서버 제목</MpGameName>
   <MpMaxPlayers>최대 플레이어</MpMaxPlayers>
   <MpAutosaveEvery>매 </MpAutosaveEvery>
-  <MpAutosaveMinutes>분 마다 자동저장</MpAutosaveMinutes>
+  <MpAutosaveDays>매일 자동 저장</MpAutosaveDays>
   <MpLanDesc1>로컬 네트워크에 서버를 엽니다.</MpLanDesc1>
   <MpLanDesc2>현재 LAN 주소: {0}</MpLanDesc2>
   <MpArbiterDesc>접속을 유지해주는 게임 내 시스템입니다.</MpArbiterDesc>

--- a/Languages/Polish/Keyed/Multiplayer.xml
+++ b/Languages/Polish/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Bezpośrednio</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Polish/Keyed/Multiplayer.xml
+++ b/Languages/Polish/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>Nazwa gry</MpGameName>
   <MpMaxPlayers>Liczba graczy</MpMaxPlayers>
   <MpAutosaveEvery>Autozapis co</MpAutosaveEvery>
-  <MpAutosaveMinutes>minut</MpAutosaveMinutes>
+  <MpAutosaveDays>dni</MpAutosaveDays>
   <MpLanDesc1>Udostępnij grę do sieci LAN</MpLanDesc1>
   <MpLanDesc2>Powiązany adres LAN: {0}</MpLanDesc2>
   <MpArbiterDesc>Dodatkowa instancja działająca w tle która pomaga przy synchronizacji gry</MpArbiterDesc>

--- a/Languages/PortugueseBrazilian/Keyed/Multiplayer.xml
+++ b/Languages/PortugueseBrazilian/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>Nome do jogo</MpGameName>
   <MpMaxPlayers>Máximo de jogadores</MpMaxPlayers>
   <MpAutosaveEvery>Salvamento automático a cada</MpAutosaveEvery>
-  <MpAutosaveMinutes>minutos</MpAutosaveMinutes>
+  <MpAutosaveDays>dias</MpAutosaveDays>
   <MpLanDesc1>Transmitir o jogo à sua rede local.</MpLanDesc1>
   <MpLanDesc2>Endereço de LAN resolvido: {0}</MpLanDesc2>
   <MpArbiterDesc>Uma instância do jogo que é executada em segundo plano e ajuda na solução de dessincronização.</MpArbiterDesc>

--- a/Languages/PortugueseBrazilian/Keyed/Multiplayer.xml
+++ b/Languages/PortugueseBrazilian/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Direto</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Russian/Keyed/Multiplayer.xml
+++ b/Languages/Russian/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Прямое</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Russian/Keyed/Multiplayer.xml
+++ b/Languages/Russian/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>Название игры</MpGameName>
   <MpMaxPlayers>Макс. игроков</MpMaxPlayers>
   <MpAutosaveEvery>Автосохранение кажд.</MpAutosaveEvery>
-  <MpAutosaveMinutes>минут</MpAutosaveMinutes>
+  <MpAutosaveDays>дней</MpAutosaveDays>
   <MpLanDesc1>Броадкастить игровую сессию по LAN.</MpLanDesc1>
   <MpLanDesc2>Вычисленный LAN адрес: {0}</MpLanDesc2>
   <MpArbiterDesc>Игра, которая запускается в трее и помогает с десинхронизацией.</MpArbiterDesc>

--- a/Languages/Slovenian/Keyed/Multiplayer.xml
+++ b/Languages/Slovenian/Keyed/Multiplayer.xml
@@ -113,6 +113,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Direktno</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Languages/Slovenian/Keyed/Multiplayer.xml
+++ b/Languages/Slovenian/Keyed/Multiplayer.xml
@@ -86,7 +86,7 @@
   <MpGameName>Ime igre</MpGameName>
   <MpMaxPlayers>Največ igralcev</MpMaxPlayers>
   <MpAutosaveEvery>Samodejno shranjevanje vsake</MpAutosaveEvery>
-  <MpAutosaveMinutes>minute</MpAutosaveMinutes>
+  <MpAutosaveDays>dnevi</MpAutosaveDays>
   <MpLanDesc1>Gostuj igro na lokalnem omrežju.</MpLanDesc1>
   <MpLanDesc2>Razrešen LAN naslov: {0}</MpLanDesc2>
   <MpArbiterDesc>Instanca igre ki teče v ozadju in pomaga s reševanjem ne skladnosti.</MpArbiterDesc>

--- a/Languages/Spanish/Keyed/Multiplayer.xml
+++ b/Languages/Spanish/Keyed/Multiplayer.xml
@@ -85,7 +85,7 @@
   <MpGameName>Nombre del juego</MpGameName>
   <MpMaxPlayers>Máximo de jugadores</MpMaxPlayers>
   <MpAutosaveEvery>Auto salvar cada</MpAutosaveEvery>
-  <MpAutosaveMinutes>minutos</MpAutosaveMinutes>
+  <MpAutosaveDays>dias</MpAutosaveDays>
   <MpLanDesc1>Transmitir el juego a tu red local.</MpLanDesc1>
   <MpLanDesc2>Dirección LAN resuelta: {0}</MpLanDesc2>
   <MpArbiterDesc>Una instancia del juego que corre en segundo plano y ayuda resolver problemas de sincronía.</MpArbiterDesc>

--- a/Languages/Spanish/Keyed/Multiplayer.xml
+++ b/Languages/Spanish/Keyed/Multiplayer.xml
@@ -112,6 +112,8 @@
   
   <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
   <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
+  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
+  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
   <MpLan>LAN</MpLan>
   <MpDirect>Directo</MpDirect>
   <MpSteam>Steam</MpSteam>

--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -151,6 +151,8 @@ namespace Multiplayer.Client
             var appendNameToAutosaveCheckboxWidth = appendNameToAutosaveLabelWidth + 30f;
             listing.CheckboxLabeled(appendNameToAutosaveLabel, ref settings.appendNameToAutosave);
 
+            listing.CheckboxLabeled("MpPauseAutosaveCounter".Translate(), ref settings.pauseAutosaveCounter, "MpPauseAutosaveCounterDesc".Translate());
+
             if (Prefs.DevMode)
                 listing.CheckboxLabeled("Show debug info", ref settings.showDevInfo);
 
@@ -220,6 +222,7 @@ namespace Multiplayer.Client
         public bool showDevInfo;
         public string serverAddress;
         public bool appendNameToAutosave;
+        public bool pauseAutosaveCounter;
 
         public override void ExposeData()
         {
@@ -231,6 +234,7 @@ namespace Multiplayer.Client
             Scribe_Values.Look(ref aggressiveTicking, "aggressiveTicking");
             Scribe_Values.Look(ref showDevInfo, "showDevInfo");
             Scribe_Values.Look(ref serverAddress, "serverAddress", "127.0.0.1");
+            Scribe_Values.Look(ref pauseAutosaveCounter, "pauseAutosaveCounter", true);
         }
     }
 }

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -243,7 +243,7 @@ namespace Multiplayer.Client
         }
 
         public static void TextFieldNumericLabeled<T>(Rect rect, string label, ref T val, ref string buffer, float labelWidth, float min = 0, float max = float.MaxValue) where T : struct
-		{
+        {
             Rect labelRect = rect;
             labelRect.width = labelWidth;
             Rect fieldRect = rect;

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -82,7 +82,7 @@ namespace Multiplayer.Client
 
             TextFieldNumericLabeled(entry.Right(150f).Width(labelWidth + 85f), $"{"MpAutosaveEvery".Translate()} ", ref settings.autosaveInterval, ref autosaveBuffer, labelWidth + 50f, 0, 999);
             Text.Anchor = TextAnchor.MiddleLeft;
-            Widgets.Label(entry.Right(200f).Right(labelWidth + 35f), $" {"MpAutosaveMinutes".Translate()}");
+            Widgets.Label(entry.Right(200f).Right(labelWidth + 35f), $" {"MpAutosaveDays".Translate()}");
             Text.Anchor = TextAnchor.UpperLeft;
             entry = entry.Down(40);
 
@@ -242,8 +242,8 @@ namespace Multiplayer.Client
             return Widgets.TextField(fieldRect, text);
         }
 
-        public static void TextFieldNumericLabeled(Rect rect, string label, ref int val, ref string buffer, float labelWidth, float min = 0, float max = float.MaxValue)
-        {
+        public static void TextFieldNumericLabeled<T>(Rect rect, string label, ref T val, ref string buffer, float labelWidth, float min = 0, float max = float.MaxValue) where T : struct
+		{
             Rect labelRect = rect;
             labelRect.width = labelWidth;
             Rect fieldRect = rect;
@@ -252,7 +252,7 @@ namespace Multiplayer.Client
             Text.Anchor = TextAnchor.MiddleRight;
             Widgets.Label(labelRect, label);
             Text.Anchor = anchor;
-            Widgets.TextFieldNumeric(fieldRect, ref val, ref buffer, min, max);
+            Widgets.TextFieldNumeric<T>(fieldRect, ref val, ref buffer, min, max);
         }
 
         public override void PostClose()

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -176,8 +176,15 @@ namespace Multiplayer.Common
 
             gameTimer++;
 
-            autosaveCountdown -= Client.Multiplayer.WorldComp.TickRateMultiplier(Client.Multiplayer.WorldComp.TimeSpeed);
-            if (settings.autosaveInterval > 0 && autosaveCountdown <= 0)
+            if (settings.autosaveInterval <= 0)
+                return;
+
+            var curSpeed = Client.Multiplayer.WorldComp.TimeSpeed;
+
+            autosaveCountdown -= (curSpeed == Verse.TimeSpeed.Paused && !Client.MultiplayerMod.settings.pauseAutosaveCounter) 
+                ? 1 : Client.Multiplayer.WorldComp.TickRateMultiplier(curSpeed);
+
+            if (autosaveCountdown <= 0)
                 DoAutosave();
         }
 

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -85,7 +85,7 @@ namespace Multiplayer.Common
             if (settings.lanAddress != null)
                 lanManager = new NetManager(new MpNetListener(this, false));
 
-        autosaveCountdown = settings.autosaveInterval * 2500 * 24;
+            autosaveCountdown = settings.autosaveInterval * 2500 * 24;
         }
 
         public bool? StartListeningNet()

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -70,9 +70,9 @@ namespace Multiplayer.Common
 
         public event Action<MultiplayerServer> NetTick;
 
-		private float autosaveCountdown;
+        private float autosaveCountdown;
 
-		public MultiplayerServer(ServerSettings settings)
+        public MultiplayerServer(ServerSettings settings)
         {
             this.settings = settings;
 
@@ -85,8 +85,8 @@ namespace Multiplayer.Common
             if (settings.lanAddress != null)
                 lanManager = new NetManager(new MpNetListener(this, false));
 
-			autosaveCountdown = settings.autosaveInterval * 2500 * 24;
-		}
+        autosaveCountdown = settings.autosaveInterval * 2500 * 24;
+        }
 
         public bool? StartListeningNet()
         {
@@ -168,7 +168,7 @@ namespace Multiplayer.Common
                 lastKeepAlive.Restart();
             }
         }
-		
+
         public void Tick()
         {
             if (gameTimer % 3 == 0)
@@ -176,8 +176,8 @@ namespace Multiplayer.Common
 
             gameTimer++;
 
-			autosaveCountdown -= Client.Multiplayer.WorldComp.TickRateMultiplier(Client.Multiplayer.WorldComp.TimeSpeed);
-			if (settings.autosaveInterval > 0 && autosaveCountdown <= 0)
+            autosaveCountdown -= Client.Multiplayer.WorldComp.TickRateMultiplier(Client.Multiplayer.WorldComp.TimeSpeed);
+            if (settings.autosaveInterval > 0 && autosaveCountdown <= 0)
                 DoAutosave();
         }
 
@@ -209,8 +209,8 @@ namespace Multiplayer.Common
 
             SendChat("Autosaving...");
 
-			autosaveCountdown = settings.autosaveInterval * 2500 * 24;
-			return true;
+            autosaveCountdown = settings.autosaveInterval * 2500 * 24;
+            return true;
         }
 
         public void Enqueue(Action action)


### PR DESCRIPTION
Autosave now mimics its singleplayer counterpart.

### Changes:

- Autosave interval is set in ingame days instead of minutes in real time.
- The countdown is influenced by ingame speed setting which means it also stops when the game is paused.

### Notes:

- New default value of 0.5 days is around the old default 8 minutes at normal speed setting.
- Autosave countdown is reset when user invokes a manual save (via /autosave chat command).