### PR TITLE
Feature/arbiter Pass custom data folder path to the arbiter.

### DIFF
--- a/Source/Client/ClientNetworking.cs
+++ b/Source/Client/ClientNetworking.cs
@@ -223,9 +223,14 @@ namespace Multiplayer.Client
 
             Multiplayer.LocalServer.SetupArbiterConnection();
 
+            string args = $"-batchmode -nographics -arbiter -logfile arbiter_log.txt -connect=127.0.0.1:{Multiplayer.LocalServer.ArbiterPort}";
+
+            if(GenCommandLine.TryGetCommandLineArg("savedatafolder", out string saveDataFolder))
+                args += $" -savedatafolder=\"{saveDataFolder}\"";
+
             Multiplayer.session.arbiter = Process.Start(
                 Process.GetCurrentProcess().MainModule.FileName,
-                $"-batchmode -nographics -arbiter -logfile arbiter_log.txt -connect=127.0.0.1:{Multiplayer.LocalServer.ArbiterPort}"
+                args
             );
         }
 


### PR DESCRIPTION
Custom save data folder path is now passed to the arbiter instance.
Allowing the arbiter to join a game created by an instance that uses a custom data folder.