### PR TITLE
[#43] When reading in mod configuration file, read in value for appendNameToAutosave

### DIFF
--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -234,6 +234,7 @@ namespace Multiplayer.Client
             Scribe_Values.Look(ref aggressiveTicking, "aggressiveTicking");
             Scribe_Values.Look(ref showDevInfo, "showDevInfo");
             Scribe_Values.Look(ref serverAddress, "serverAddress", "127.0.0.1");
+            Scribe_Values.Look(ref appendNameToAutosave, "appendNameToAutosave", false);
             Scribe_Values.Look(ref pauseAutosaveCounter, "pauseAutosaveCounter", true);
         }
     }


### PR DESCRIPTION
Feature Enhancement simply didn't read in the value of appendNameToAutosave written to mod config file while the MpSettings class values were being read in. Fix for #43 