### PR TITLE
Fix contributors.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,7 @@ To pull the project, issue these commands in the git shell:
 
 ```bash
 cd "/c/Program Files (x86)/Steam/steamapps/common/RimWorld/Mods"
-git clone git@github.com:Parexy/Multiplayer.git
+git clone https://github.com/Parexy/Multiplayer.git
 ```
 
 If your RimWorld installation is in a non-standard location, cd to that `Mods` directory first before cloning. 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,8 +6,16 @@ To pull the project, issue these commands in the git shell:
 
 ```bash
 cd "/c/Program Files (x86)/Steam/steamapps/common/RimWorld/Mods"
+```
+Then if you have a valid SSH keypair run:
+```bash
+git clone git@github.com:Parexy/Multiplayer.git
+```
+Otherwise, run:
+```bash
 git clone https://github.com/Parexy/Multiplayer.git
 ```
+
 
 If your RimWorld installation is in a non-standard location, cd to that `Mods` directory first before cloning. 
 


### PR DESCRIPTION
Previous command did not work.
```bash
$ git clone git@github.com:Parexy/Multiplayer.git
Cloning into 'Multiplayer'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```