### PR TITLE
PR#70 Enable aggressive ticking by default

### DIFF
--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -218,7 +218,7 @@ namespace Multiplayer.Client
         public bool autoAcceptSteam;
         public bool transparentChat;
         public int autosaveSlots = 5;
-        public bool aggressiveTicking;
+        public bool aggressiveTicking = true;
         public bool showDevInfo;
         public string serverAddress = "127.0.0.1";
         public bool appendNameToAutosave;

--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -232,7 +232,7 @@ namespace Multiplayer.Client
             Scribe_Values.Look(ref autoAcceptSteam, "autoAcceptSteam");
             Scribe_Values.Look(ref transparentChat, "transparentChat");
             Scribe_Values.Look(ref autosaveSlots, "autosaveSlots", 5);
-            Scribe_Values.Look(ref aggressiveTicking, "aggressiveTicking");
+            Scribe_Values.Look(ref aggressiveTicking, "aggressiveTicking", true);
             Scribe_Values.Look(ref showDevInfo, "showDevInfo");
             Scribe_Values.Look(ref serverAddress, "serverAddress", "127.0.0.1");
             Scribe_Values.Look(ref appendNameToAutosave, "appendNameToAutosave", false);


### PR DESCRIPTION
Enable the mod option 'aggressive ticking' by default. Using 'aggressive ticking' seems to solve a lot of desyncing issues.