### PR TITLE
Added IPv6 parsing support

### DIFF
--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -193,16 +193,19 @@ namespace Multiplayer.Client
         {
             if (GenCommandLine.TryGetCommandLineArg("connect", out string ip))
             {
-                int port = MultiplayerServer.DefaultPort;
+                int port;
 
-                var split = ip.Split(':');
-                if (split.Length == 0)
+                MatchCollection matches = Regex.Matches(ip, "(.*)((?::))((?:[0-9]+))$");
+                if (matches.Count == 1) // Port is included, use regex
+                {
+                    ip = matches[0].Groups[1].Value;
+                    int.TryParse(matches[0].Groups[3].Value, out port);
+                }
+                else // Port is excluded, use default port value
+                {
                     ip = "127.0.0.1";
-                else if (split.Length >= 1)
-                    ip = split[0];
-
-                if (split.Length == 2)
-                    int.TryParse(split[1], out port);
+                    port = MultiplayerServer.DefaultPort;
+                }
 
                 DoubleLongEvent(() => ClientUtil.TryConnect(ip, port), "Connecting");
             }

--- a/Source/Client/Windows/ServerBrowser.cs
+++ b/Source/Client/Windows/ServerBrowser.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml;
 using UnityEngine;
@@ -515,16 +516,25 @@ namespace Multiplayer.Client
             {
                 string addr = MultiplayerMod.settings.serverAddress.Trim();
                 int port = MultiplayerServer.DefaultPort;
-                string[] hostport = addr.Split(':');
-                if (hostport.Length == 2)
-                    int.TryParse(hostport[1], out port);
-                else
-                    port = MultiplayerServer.DefaultPort;
-
-                Log.Message("Connecting directly");
+                
                 try
                 {
-                    Find.WindowStack.Add(new ConnectingWindow(hostport[0], port) { returnToServerBrowser = true });
+                    string ip;
+                    MatchCollection matches = Regex.Matches(addr, "(.*)((?::))((?:[0-9]+))$");
+                    if (matches.Count == 1) // Port is included, use regex
+                    {
+                        ip = matches[0].Groups[1].Value;
+                        int.TryParse(matches[0].Groups[3].Value, out port);
+                    }
+                    else // Port is excluded, use default port value
+                    {
+                        ip = addr;
+                        port = MultiplayerServer.DefaultPort;
+                    }
+
+                    Log.Message("Connecting directly");
+
+                    Find.WindowStack.Add(new ConnectingWindow(ip, port) { returnToServerBrowser = true });
                     MultiplayerMod.settings.Write();
                     Close(false);
                 }

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -86,18 +86,34 @@ namespace Multiplayer.Common
 
         public bool? StartListeningNet()
         {
-            return netManager?.Start(IPAddress.Parse(settings.bindAddress), IPAddress.IPv6Any, settings.bindPort);
+            IPAddress addr = IPAddress.Parse(settings.bindAddress);
+            if (addr.AddressFamily == AddressFamily.InterNetwork)
+            {
+                return netManager?.Start(IPAddress.Parse(settings.bindAddress), IPAddress.IPv6Any, settings.bindPort);
+            }
+            else
+            {
+                return netManager?.Start(IPAddress.Loopback, IPAddress.Parse(settings.bindAddress), settings.bindPort);
+            }
         }
 
         public bool? StartListeningLan()
         {
-            return lanManager?.Start(IPAddress.Parse(settings.lanAddress), IPAddress.IPv6Any, 0);
+            IPAddress addr = IPAddress.Parse(settings.bindAddress);
+            if (addr.AddressFamily == AddressFamily.InterNetwork)
+            {
+                return lanManager?.Start(IPAddress.Parse(settings.lanAddress), IPAddress.IPv6Any, 0);
+            }
+            else
+            {
+                return lanManager?.Start(IPAddress.Loopback, IPAddress.Parse(settings.lanAddress), 0);
+            }
         }
 
         public void SetupArbiterConnection()
         {
             arbiter = new NetManager(new MpNetListener(this, true));
-            arbiter.Start(IPAddress.Loopback, IPAddress.IPv6Any, 0);
+            arbiter.Start(IPAddress.Loopback, IPAddress.IPv6Loopback, 0);
         }
 
         public void Run()


### PR DESCRIPTION
Reopening PR56 on correct base branch.

Resolves #55.

This PR allows the UI to parse and handle IPv6 syntax. However I encountered some connection issues:

I could not connect on my LAN IPv6 address but I could ping it without issue.
The arbiter is able to connect with no problems.
My ISP does not provide me an IPv6 address so I could not test this over public network.

I'll try to figure this out myself but I am new to C# development and LiteNetLib, so I am opening a draft pull request in case anyone else can write a quick fix.

Thanks

Edit: Note that IPv6 addresses require enclosing square brackets even when a port is not specified.