### PR TITLE
Reintroduced player colors, caravan fix, async/arbiter changes

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -6,6 +6,6 @@
   <url>https://github.com/Parexy/Multiplayer/</url>
   <description>&lt;color=red&gt;&lt;b&gt;Important: &lt;/b&gt; This mod should be loaded right after Core and before HugsLib to work properly!&lt;/color&gt;\n
 Multiplayer mod for rimworld.
-This is version 0.4.8.3.color
+This is version 0.4.9
   </description>
 </ModMetaData>

--- a/About/About.xml
+++ b/About/About.xml
@@ -6,6 +6,6 @@
   <url>https://github.com/Parexy/Multiplayer/</url>
   <description>&lt;color=red&gt;&lt;b&gt;Important: &lt;/b&gt; This mod should be loaded right after Core and before HugsLib to work properly!&lt;/color&gt;\n
 Multiplayer mod for rimworld.
-This is version 0.4.8.3
+This is version 0.4.8.3.color
   </description>
 </ModMetaData>

--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -3,7 +3,7 @@
 <Manifest>
 
   <identifier>Multiplayer</identifier>
-  <version>0.4.8.3</version>
+  <version>0.4.9</version>
   <manifestUri>https://raw.githubusercontent.com/Parexy/Multiplayer/master/About/Manifest.xml</manifestUri>
   <downloadUri>https://github.com/Parexy/Multiplayer/releases/latest</downloadUri>
 

--- a/Source/Client/ClientNetworking.cs
+++ b/Source/Client/ClientNetworking.cs
@@ -212,6 +212,7 @@ namespace Multiplayer.Client
             localServerConn.State = ConnectionStateEnum.ServerPlaying;
 
             var serverPlayer = Multiplayer.LocalServer.OnConnected(localServerConn);
+            serverPlayer.color = new ColorRGB(255, 0, 0);
             serverPlayer.status = PlayerStatus.Playing;
             serverPlayer.SendPlayerList();
 

--- a/Source/Client/MultiplayerSession.cs
+++ b/Source/Client/MultiplayerSession.cs
@@ -195,6 +195,7 @@ namespace Multiplayer.Client
         public int ticksBehind;
         public PlayerType type;
         public PlayerStatus status;
+        public Color color;
 
         public ulong steamId;
         public string steamPersonaName;
@@ -231,11 +232,14 @@ namespace Multiplayer.Client
 
             var ticksBehind = data.ReadInt32();
 
+            var color = new Color(data.ReadByte() / 255f, data.ReadByte() / 255f, data.ReadByte() / 255f);
+
             return new PlayerInfo(id, username, latency, type)
             {
                 status = status,
                 steamId = steamId,
                 steamPersonaName = steamName,
+                color = color,
                 ticksBehind = ticksBehind
             };
         }

--- a/Source/Client/PlayerCursors.cs
+++ b/Source/Client/PlayerCursors.cs
@@ -24,7 +24,7 @@ namespace Multiplayer.Client
                 if (player.username == Multiplayer.username) continue;
                 if (player.map != curMap) continue;
 
-                GUI.color = new Color(1, 1, 1, 0.5f);
+                GUI.color = player.color * new Color(1, 1, 1, 0.5f);
                 var pos = Vector3.Lerp(player.lastCursor, player.cursor, (float)(Multiplayer.Clock.ElapsedMillisDouble() - player.updatedAt) / 50f).MapToUIPosition();
 
                 var icon = Multiplayer.icons.ElementAtOrDefault(player.cursorIcon);
@@ -44,7 +44,7 @@ namespace Multiplayer.Client
 
                 if (player.dragStart != PlayerInfo.Invalid)
                 {
-                    GUI.color = new Color(1, 1, 1, 0.2f);
+                    GUI.color = player.color * new Color(1, 1, 1, 0.2f);
                     Widgets.DrawBox(new Rect() { min = player.dragStart.MapToUIPosition(), max = pos }, 2);
                 }
 

--- a/Source/Client/Sync/SyncHandlers.cs
+++ b/Source/Client/Sync/SyncHandlers.cs
@@ -302,9 +302,9 @@ namespace Multiplayer.Client
         [MpPrefix(typeof(TransferableUIUtility), "DoCountAdjustInterface")]
         static void TransferableAdjustTo(Transferable trad)
         {
-            var session = MpTradeSession.current ?? 
-                Multiplayer.WorldComp.splitSession ?? 
-                (ISessionWithTransferables)MpFormingCaravanWindow.drawing?.Session ?? 
+            var session = MpTradeSession.current ??
+                (Multiplayer.Client != null ? Multiplayer.WorldComp.splitSession : null) ??
+                (ISessionWithTransferables)MpFormingCaravanWindow.drawing?.Session ??
                 MpLoadTransportersWindow.drawing?.Session;
             if (session != null)
                 SyncTradeableCount.Watch(new MpTransferableReference(session, trad));

--- a/Source/Client/Windows/ChatWindow.cs
+++ b/Source/Client/Windows/ChatWindow.cs
@@ -109,6 +109,8 @@ namespace Multiplayer.Client
                 ClickPlayer,
                 extra: (p, rect) =>
                 {
+                    Widgets.DrawRectFast(new Rect(rect.x + 137, rect.y, 3f, rect.height), p.color * new Color(0.8f, 0.8f, 0.8f));
+
                     if (p.type == PlayerType.Steam)
                     {
                         var steamIcon = new Rect(rect.xMax - 24f, 0, 24f, 24f);

--- a/Source/Client/Windows/HostWindow.cs
+++ b/Source/Client/Windows/HostWindow.cs
@@ -119,16 +119,19 @@ namespace Multiplayer.Client
                 entry = entry.Down(30);
             }
 
-            TooltipHandler.TipRegion(entry.Width(checkboxWidth), "MpArbiterDesc".Translate());
-            CheckboxLabeled(entry.Width(checkboxWidth), "The Arbiter:  ", ref settings.arbiter, placeTextNearCheckbox: true);
-            entry = entry.Down(30);
+            if (MpVersion.IsDebug)
+            {
+                TooltipHandler.TipRegion(entry.Width(checkboxWidth), "MpArbiterDesc".Translate());
+                CheckboxLabeled(entry.Width(checkboxWidth), "The Arbiter:  ", ref settings.arbiter, placeTextNearCheckbox: true);
+                entry = entry.Down(30);
+            }
 
-            /*if (MpVersion.IsDebug)
+            if (MpVersion.IsDebug)
             {
                 TooltipHandler.TipRegion(entry.Width(checkboxWidth), $"{"MpAsyncTimeDesc".Translate()}\n\n{"MpExperimentalFeature".Translate()}");
                 CheckboxLabeled(entry.Width(checkboxWidth), "Async time:  ", ref asyncTime, placeTextNearCheckbox: true);
                 entry = entry.Down(30);
-            }*/
+            }
 
             if (Prefs.DevMode)
             {

--- a/Source/Common/MultiplayerServer.cs
+++ b/Source/Common/MultiplayerServer.cs
@@ -385,6 +385,7 @@ namespace Multiplayer.Common
             if (arbiter)
             {
                 player.type = PlayerType.Arbiter;
+                player.color = new ColorRGB(128, 128, 128);
             }
         }
 
@@ -465,6 +466,7 @@ namespace Multiplayer.Common
         public IConnection conn;
         public PlayerType type;
         public PlayerStatus status;
+        public ColorRGB color;
         public int ticksBehind;
 
         public ulong steamId;
@@ -551,6 +553,9 @@ namespace Multiplayer.Common
             writer.WriteULong(steamId);
             writer.WriteString(steamPersonaName);
             writer.WriteInt32(ticksBehind);
+            writer.WriteByte(color.r);
+            writer.WriteByte(color.g);
+            writer.WriteByte(color.b);
 
             return writer.ToArray();
         }

--- a/Source/Common/ServerConnection.cs
+++ b/Source/Common/ServerConnection.cs
@@ -69,6 +69,19 @@ namespace Multiplayer.Common
             connection.Send(Packets.Server_DefsOK, Server.settings.gameName, Player.id);
         }
 
+        private static ColorRGB[] PlayerColors = new ColorRGB[]
+{
+            new ColorRGB(179,  77, 0),
+            new ColorRGB(204, 204, 0),
+            new ColorRGB( 25, 204, 0),
+            new ColorRGB( 25, 115, 0),
+            new ColorRGB(  0, 128, 255),
+            new ColorRGB( 51,  51, 255),
+            new ColorRGB(102,   0, 255)
+};
+
+        private static Dictionary<string, ColorRGB> givenColors = new Dictionary<string, ColorRGB>();
+
         [PacketHandler(Packets.Client_Username)]
         public void HandleClientUsername(ByteReader data)
         {
@@ -99,6 +112,13 @@ namespace Multiplayer.Common
 
             Server.SendNotification("MpPlayerConnected", Player.Username);
             Server.SendChat($"{Player.Username} has joined.");
+
+            if (!Player.IsArbiter)
+            {
+                if (!givenColors.TryGetValue(username, out ColorRGB color))
+                    givenColors[username] = color = PlayerColors[givenColors.Count % PlayerColors.Length];
+                Player.color = color;
+            }
 
             var writer = new ByteWriter();
             writer.WriteByte((byte)PlayerListAction.Add);

--- a/Source/Common/Version.cs
+++ b/Source/Common/Version.cs
@@ -2,8 +2,8 @@ namespace Multiplayer.Common
 {
     public static class MpVersion
     {
-        public const string Version = "0.4.8.3";
-        public const int Protocol = 17;
+        public const string Version = "0.4.9";
+        public const int Protocol = 18;
 
         public const string apiAssemblyName = "0MultiplayerAPI";
 


### PR DESCRIPTION
- Reintroduced player colors though not to the full extend of what zetrith did, but he never published all of the code he made for it.
- Fixes caravan creation being broken in sp after the last caravan splitting patch.
- Re-enabled async time setting in the host menu, but currently only for the debug build so it can be tested.
- Disabled arbiter setting in host menu for the release build.
- Updated version to 0.4.9